### PR TITLE
Fixed small equation on proof for Law of Total Probability

### DIFF
--- a/cs130/content/INDEX.html
+++ b/cs130/content/INDEX.html
@@ -2849,7 +2849,7 @@
                 <p>
                     <b><i>Proof.</i></b> 
                     \begin{align}
-                        P(A | B_i) P(B_i) &= \frac{P(A \cap B{i})}{P(B_i) \cdot P(B_i)} \\
+                        P(A | B_i) P(B_i) &= \frac{P(A \cap B{i})}{P(B_i)} \cdot P(B_i) \\
                         &= P(A \cap B_i) \\
                         \therefore \sum_{i=1}^{k} P(A | B_i) P(B_i) &= \sum_{i=1}^{k} P(A \cap B_i) \\
                         \therefore P(\bigcup_{i=1}^{k} A \cap B_i) &= P (A \cap \bigcup_{i=1}^{k} B_i) \\


### PR DESCRIPTION
P(Bi) should be multiplied with the numerator not the denominator of the equation